### PR TITLE
Update doc for macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ Additional logging information can be turned on and off using these `./configure
 
 # Build
 
-If you are using MacOS, make sure you install `automake`, `cmake`, and `libtool`:
+If you are using MacOS, make sure you install `automake`, `cmake`, `libtool`, and `qt5`:
 ```
 $ brew install automake
 $ brew install cmake
 $ brew install libtool
+$ brew install qt5
+$ brew link qt5 --force
 ```
 
 Build all the binaries:


### PR DESCRIPTION
Update instruction how to install and link Qt5 library for mac which is required to run sherlock265