### PR TITLE
fix chroma QP reporting

### DIFF
--- a/libde265/transform.cc
+++ b/libde265/transform.cc
@@ -199,8 +199,8 @@ void decode_quantization_parameters(thread_context* tctx, int xC,int yC,
 
   tctx->img->set_QPY(xCUBase, yCUBase, log2CbSize, QPY);
   tctx->currentQPY = QPY;
-  tctx->img->set_QPCb(xCUBase, yCUBase, log2CbSize, qPCb + sps.QpBdOffset_C);
-  tctx->img->set_QPCr(xCUBase, yCUBase, log2CbSize, qPCr + sps.QpBdOffset_C);
+  tctx->img->set_QPCb(xCUBase, yCUBase, log2CbSize, qPCb);
+  tctx->img->set_QPCr(xCUBase, yCUBase, log2CbSize, qPCr);
 
   /*
   printf("SET QPY POC=%d %d;%d-%d;%d = %d\n",ctx->img->PicOrderCntVal,xCUBase,yCUBase,


### PR DESCRIPTION
currently QP_Y is reported without the `QpBdOffset_Y` offset added, but QP_Cb and QP_Cr report the value  `+QpBdOffset_C`. 

We effectively log `QP_Y` but `QP'_Cb` and `QP'_Cr`.  This is confusing because it makes it seem like there is a positive chroma QP offset applied in 10-bit encodings. We should consistently use either `QP` or `QP'` (and arguably we should report the non-prime version as that is consistent across bit depths).